### PR TITLE
feat: Add layer order controls (Bring Forward / Send Backward)

### DIFF
--- a/src/app/miniroom/components/DraggableItem.tsx
+++ b/src/app/miniroom/components/DraggableItem.tsx
@@ -20,6 +20,8 @@ interface DraggableItemProps {
     onRotate: () => void;
     onFlip: () => void;
     onScale: (delta: number) => void;
+    onBringForward: () => void;
+    onSendBackward: () => void;
     zIndex?: number;
 }
 
@@ -34,6 +36,8 @@ export const DraggableItem = ({
     onRotate,
     onFlip,
     onScale,
+    onBringForward,
+    onSendBackward,
     zIndex,
 }: DraggableItemProps) => {
     const handleDrag = (dx: number, dy: number) => {
@@ -175,6 +179,22 @@ export const DraggableItem = ({
                     >
                         -
                     </button>
+                    <div className="w-px h-4 bg-gray-300 mx-1" /> {/* Divider */}
+                    <button
+                        onClick={onBringForward}
+                        className="p-1 hover:bg-gray-100 rounded text-gray-700 font-bold"
+                        title="Bring Forward"
+                    >
+                        ⬆
+                    </button>
+                    <button
+                        onClick={onSendBackward}
+                        className="p-1 hover:bg-gray-100 rounded text-gray-700 font-bold"
+                        title="Send Backward"
+                    >
+                        ⬇
+                    </button>
+                    <div className="w-px h-4 bg-gray-300 mx-1" /> {/* Divider */}
                     <button
                         onClick={() => onDelete(item.instanceId)}
                         className="p-1 hover:bg-red-100 rounded text-red-600 font-bold"

--- a/src/app/miniroom/components/RoomCanvas.tsx
+++ b/src/app/miniroom/components/RoomCanvas.tsx
@@ -13,6 +13,8 @@ interface RoomCanvasProps {
     onRotateItem: (id: string) => void;
     onFlipItem: (id: string) => void;
     onScaleItem: (id: string, delta: number) => void;
+    onBringForward: (id: string) => void;
+    onSendBackward: (id: string) => void;
     onBackgroundClick: () => void;
     width: number;
     height: number;
@@ -28,6 +30,8 @@ export const RoomCanvas = ({
     onRotateItem,
     onFlipItem,
     onScaleItem,
+    onBringForward,
+    onSendBackward,
     onBackgroundClick,
     width,
     height,
@@ -69,6 +73,8 @@ export const RoomCanvas = ({
                         onRotate={() => onRotateItem(item.instanceId)}
                         onFlip={() => onFlipItem(item.instanceId)}
                         onScale={(delta) => onScaleItem(item.instanceId, delta)}
+                        onBringForward={() => onBringForward(item.instanceId)}
+                        onSendBackward={() => onSendBackward(item.instanceId)}
                         // Depth Sorting: Lower Y (higher up) = Background. Higher Y (lower down) = Foreground.
                         // We use (posY + height) to align by the "feet" of the item.
                         zIndex={Math.floor(item.posY + (itemDef.height * (item.scale || 1)))}

--- a/src/app/miniroom/hooks/useMiniroom.ts
+++ b/src/app/miniroom/hooks/useMiniroom.ts
@@ -205,6 +205,28 @@ export const useMiniroom = () => {
         setSelectedItemId(instanceId);
     }, []);
 
+    const bringForward = useCallback((instanceId: string) => {
+        setRoom((prev) => {
+            const items = [...prev.items];
+            const index = items.findIndex((i) => i.instanceId === instanceId);
+            if (index === -1 || index === items.length - 1) return prev; // Already at top
+            // Swap with next item
+            [items[index], items[index + 1]] = [items[index + 1], items[index]];
+            return { ...prev, items };
+        });
+    }, []);
+
+    const sendBackward = useCallback((instanceId: string) => {
+        setRoom((prev) => {
+            const items = [...prev.items];
+            const index = items.findIndex((i) => i.instanceId === instanceId);
+            if (index <= 0) return prev; // Already at bottom
+            // Swap with previous item
+            [items[index - 1], items[index]] = [items[index], items[index - 1]];
+            return { ...prev, items };
+        });
+    }, []);
+
     return {
         room,
         selectedItemId,
@@ -215,6 +237,8 @@ export const useMiniroom = () => {
         flipItem,
         scaleItem,
         deleteItem,
+        bringForward,
+        sendBackward,
         setBackground,
         currentBackground,
     };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,6 +21,8 @@ export default function MiniroomPage() {
     rotateItem,
     flipItem,
     scaleItem,
+    bringForward,
+    sendBackward,
     setBackground,
     currentBackground,
   } = useMiniroom();
@@ -78,6 +80,8 @@ export default function MiniroomPage() {
             onRotateItem={rotateItem}
             onFlipItem={flipItem}
             onScaleItem={scaleItem}
+            onBringForward={bringForward}
+            onSendBackward={sendBackward}
             onBackgroundClick={() => selectItem(null)}
             width={currentBackground.width}
             height={currentBackground.height}

--- a/src/config/appVersion.ts
+++ b/src/config/appVersion.ts
@@ -5,9 +5,15 @@ export interface ReleaseNote {
     fixes?: string[];
 }
 
-export const APP_VERSION = "v1.4.6";
+export const APP_VERSION = "v1.5.0";
 
 export const CHANGELOG: ReleaseNote[] = [
+    {
+        version: "v1.5.0",
+        date: "2025-12-18",
+        features: ["Added layer order controls: Bring Forward (⬆) / Send Backward (⬇) buttons in toolbar"],
+        fixes: [],
+    },
     {
         version: "v1.4.9",
         date: "2025-12-18",


### PR DESCRIPTION
## Summary
Adds layer order adjustment buttons to the item toolbar.

## Changes
- Added `bringForward` / `sendBackward` functions to `useMiniroom` hook
- Added ⬆ (Bring Forward) / ⬇ (Send Backward) buttons to item toolbar
- Updated `RoomCanvas` and `page.tsx` to pass new handlers
- Bumped version to **v1.5.0**

## Testing
- [x] `npm run build` passes
- [ ] Manual testing in browser

Closes #1