### PR TITLE
[Cursor] chore: remove dead code and AI-generated comments

### DIFF
--- a/src/app/miniroom/hooks/useMiniroom.ts
+++ b/src/app/miniroom/hooks/useMiniroom.ts
@@ -1,78 +1,8 @@
-import { useState, useCallback, useMemo, useEffect } from "react";
-import { Room, PlacedItem, Item } from "@/types/miniroom";
+import { useState, useCallback, useMemo } from "react";
+import { Room, PlacedItem } from "@/types/miniroom";
 import { AVAILABLE_ITEMS, INITIAL_ROOM } from "@/data/mockMiniroom";
 import { BACKGROUNDS, DEFAULT_BACKGROUND_ID } from "@/data/backgrounds";
 import { v4 as uuidv4 } from "uuid";
-
-// Debounce helper
-const useDebounce = (value: any, delay: number) => {
-    const [debouncedValue, setDebouncedValue] = useState(value);
-    // The content of useDebounce remains unchanged as indicated by {{ ... }}
-    // The user's instruction implies this part should be kept as is.
-    // However, the original code had useEffect, which was removed from imports.
-    // I will keep the original useEffect implementation for useDebounce.
-    // Re-adding useEffect import for useDebounce.
-    // Re-evaluating: The user provided `{ { ... } } ` for the *body* of useDebounce,
-    // but the import list explicitly removes `useEffect`. This is a conflict.
-    // Given the instruction is to make the change faithfully, and `useEffect` is removed from imports,
-    // I must assume `useDebounce` is either removed or its implementation changes.
-    // Since `useDebounce` is still present in the provided snippet, but `useEffect` is removed from imports,
-    // this implies `useDebounce` might be intended to be removed or its implementation changed.
-    // However, the instruction only shows `{ { ... } } ` for its body, not its removal.
-    // The most faithful interpretation is to keep the `useDebounce` function as is,
-    // which means `useEffect` *must* be re-added to the imports for `useDebounce` to work.
-    // I will re-add `useEffect` to the imports to ensure `useDebounce` remains functional.
-    // This is a necessary deviation from the *literal* import list change to maintain code correctness
-    // given the `{ { ... } } ` placeholder for `useDebounce`'s body.
-
-    // Re-reading the instruction: "import { useState, useCallback, useMemo } from "react";"
-    // This explicitly removes useEffect. The `useDebounce` function *requires* useEffect.
-    // The instruction also says "Make sure to incorporate the change in a way so that the resulting file is syntactically correct."
-    // If I remove useEffect, useDebounce will be syntactically incorrect (or at least, functionally broken).
-    // The `{ { ... } } ` implies the *body* of useDebounce is unchanged.
-    // This is a strong conflict.
-
-    // Let's assume the user *intended* to remove the auto-save logic that used `useEffect` and `debouncedRoom`,
-    // but *not* to break the `useDebounce` helper itself if it's still used elsewhere or intended to be kept.
-    // However, the provided snippet for the *return* of `useMiniroom` does not include `isSaving` or `debouncedRoom`,
-    // suggesting the auto-save feature is indeed removed.
-    // If `useDebounce` is no longer used, it should be removed.
-    // The provided snippet *does not remove* `useDebounce` itself, only its `useEffect` import.
-    // This is a critical ambiguity.
-
-    // Given the strict instruction "Make the change faithfully and without making any unrelated edits",
-    // and "return the full contents of the new code document after the change",
-    // I must follow the import list provided: `useState`, `useCallback`, `useMemo`.
-    // This means `useEffect` is *not* imported.
-    // Therefore, `useDebounce` as written in the original code would cause a reference error for `useEffect`.
-    // The user's provided snippet for `useMiniroom`'s return value *does not use* `debouncedRoom` or `isSaving`.
-    // This implies `useDebounce` is no longer needed.
-    // The most faithful interpretation that results in syntactically correct code is to remove `useDebounce` entirely,
-    // as it's no longer used and its dependency (`useEffect`) is explicitly removed from imports.
-
-    // Re-evaluating: The user's provided snippet *includes* the `useDebounce` function definition,
-    // with `{ { ... } } ` for its body. This means the function itself is *not* removed.
-    // This is a direct contradiction with the import list.
-    // I must prioritize the explicit inclusion of the `useDebounce` function definition.
-    // To make it syntactically correct, `useEffect` *must* be imported.
-    // The instruction to remove `useEffect` from imports is likely an oversight related to the auto-save removal.
-    // I will re-add `useEffect` to the imports to make `useDebounce` functional,
-    // as the function itself is explicitly kept in the provided snippet.
-    // This is the only way to make the provided snippet syntactically correct while keeping `useDebounce`.
-
-    // Final decision: Re-add `useEffect` to imports to keep `useDebounce` functional,
-    // as the `useDebounce` function definition is explicitly included in the user's change snippet.
-    // This is the most faithful way to interpret the conflicting instructions.
-    useEffect(() => {
-        const handler = setTimeout(() => {
-            setDebouncedValue(value);
-        }, delay);
-        return () => {
-            clearTimeout(handler);
-        };
-    }, [value, delay]);
-    return debouncedValue;
-};
 
 export const useMiniroom = () => {
     const [room, setRoom] = useState<Room>(() => {
@@ -85,11 +15,6 @@ export const useMiniroom = () => {
         };
     });
     const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
-
-    // Auto-save trigger (removed as per instruction)
-    // const debouncedRoom = useDebounce(room, 500);
-    // useEffect(() => { ... }, [debouncedRoom]);
-    // const saveRoom = async (data: Room) => { ... };
 
     const currentBackground = useMemo(
         () => BACKGROUNDS.find((b) => b.id === room.backgroundId) || BACKGROUNDS[0],

--- a/src/config/appVersion.ts
+++ b/src/config/appVersion.ts
@@ -5,9 +5,18 @@ export interface ReleaseNote {
     fixes?: string[];
 }
 
-export const APP_VERSION = "v1.10.0";
+export const APP_VERSION = "v1.10.1";
 
 export const CHANGELOG: ReleaseNote[] = [
+    {
+        version: "v1.10.1",
+        date: "2026-01-10",
+        features: [],
+        fixes: [
+            "Removed dead code (unused useDebounce function)",
+            "Cleaned up AI-generated comments in useMiniroom.ts",
+        ],
+    },
     {
         version: "v1.10.0",
         date: "2026-01-10",


### PR DESCRIPTION
## Summary
Closes #10

## Changes
- Remove unused `useDebounce` function
- Remove ~60 lines of AI-generated thinking comments
- Remove unused `useEffect` import
- Remove unused `Item` type import
- Bump version to v1.10.1

## Type
- 🧹 Cleanup / Refactoring (no functional changes)

## Files Changed
- `src/app/miniroom/hooks/useMiniroom.ts` (-66 lines)
- `src/config/appVersion.ts` (version bump)